### PR TITLE
Improve compatibility with other frameworks and future OMF.

### DIFF
--- a/functions/lh.fish
+++ b/functions/lh.fish
@@ -1,0 +1,13 @@
+function lh -a port
+  if not type -q open
+    echo 'Requires open (MacOS only) to be installed'
+    return 1
+  end
+
+  if [ (count $argv) -ne 1 ]
+    echo 'You need to specify a port to open'
+    return 1
+  end
+
+  command open http://localhost:$port
+end

--- a/init.fish
+++ b/init.fish
@@ -8,7 +8,6 @@
 # open an arbitrary port using the `lh` command
 # $ lh 3001
 
-
 set -l common_localhost_ports 3000 4000 5000 6000 7000 8000 8001 9000 8080
 
 for port in $common_localhost_ports

--- a/localhost.load
+++ b/localhost.load
@@ -8,23 +8,6 @@
 # open an arbitrary port using the `lh` command
 # $ lh 3001
 
-## Functions
-function _open-installed
-  which open >/dev/null ^&1
-end
-
-## Main program
-function lh
-  if _open-installed
-    if [ (count $argv) -lt 1 ]
-        echo "You need to specify a port to open"
-        return 1
-    end
-    command open http://localhost:$argv
-  else
-    echo 'Requires open (MacOS only) to be installed'
-  end
-end
 
 set -l common_localhost_ports 3000 4000 5000 6000 7000 8000 8001 9000 8080
 


### PR DESCRIPTION
- Extract functions from `init.fish` to take advantage of autoloading.
- Use `init.fish` instead of `*.load` to require files on load.
